### PR TITLE
Add /xsub modmail commands + per-sub access health tracker

### DIFF
--- a/.github/workflows/run_bot.yml
+++ b/.github/workflows/run_bot.yml
@@ -35,10 +35,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Stage the database and any public log files that changed.
-          # The bot only re-writes .md/.html when something was actually logged,
-          # so on idle runs only bans.db touches will be committed (or nothing).
-          git add bans.db public_ban_log.json public_ban_log.md public_ban_log.html 2>/dev/null || true
+          # Stage the database, public log files, and the per-sub health
+          # tracker that flag access regressions. The bot only re-writes
+          # .md/.html when something was actually logged, so on idle runs
+          # mostly bans.db and bot_health.json will see touches.
+          git add bans.db bot_health.json public_ban_log.json public_ban_log.md public_ban_log.html 2>/dev/null || true
 
           if ! git diff --cached --quiet; then
             git commit -m "Update ban database and public log"

--- a/bot_config.py
+++ b/bot_config.py
@@ -110,6 +110,75 @@ class Database:
             con.commit()
             return deleted_count
 
+    # -- Modmail-driven lookups & mutations ----------------------------------
+
+    def find_user_records(self, username):
+        """All ban records for a username (case-insensitive). Most recent first."""
+        try:
+            with closing(self._get_conn()) as con:
+                con.row_factory = sqlite3.Row
+                rows = con.execute(
+                    "SELECT * FROM bans WHERE lower(username) = ? "
+                    "ORDER BY timestamp DESC",
+                    (username.lower(),),
+                ).fetchall()
+                return [dict(r) for r in rows]
+        except Exception as e:
+            print(f"[DB_ERROR] find_user_records({username}): {e}")
+            return []
+
+    def apply_pardon(self, username, source_sub, mod, mod_sub, when):
+        """
+        Mark a (username, source_sub) row as pardoned. Same effect as the
+        modlog-driven unban: sets manual_override='yes' and records who
+        forgave, where, and when. Returns True if a row was updated.
+        """
+        try:
+            with closing(self._get_conn()) as con:
+                cur = con.execute(
+                    "UPDATE bans SET manual_override = 'yes', "
+                    "moderator_name = ?, mod_sub = ?, forgive_timestamp = ? "
+                    "WHERE lower(username) = ? AND lower(source_sub) = ?",
+                    (mod, mod_sub, when, username.lower(), source_sub.lower()),
+                )
+                con.commit()
+                return cur.rowcount > 0
+        except Exception as e:
+            print(f"[DB_ERROR] apply_pardon({username}, {source_sub}): {e}")
+            return False
+
+    def add_exemption(self, row_id, exempt_sub):
+        """
+        Append a sub to the exempt_subs CSV on a single row, deduped and
+        case-folded. Returns True on success.
+        """
+        exempt_sub = exempt_sub.lower().lstrip("r/").strip("/")
+        if not exempt_sub:
+            return False
+        try:
+            with closing(self._get_conn()) as con:
+                con.row_factory = sqlite3.Row
+                row = con.execute(
+                    "SELECT exempt_subs FROM bans WHERE id = ?", (row_id,)
+                ).fetchone()
+                if row is None:
+                    return False
+                current = (row["exempt_subs"] or "").lower()
+                parts = {p.strip() for p in current.split(",") if p.strip()}
+                if exempt_sub in parts:
+                    return True  # already exempt, no-op success
+                parts.add(exempt_sub)
+                new_field = ", ".join(sorted(parts))
+                con.execute(
+                    "UPDATE bans SET exempt_subs = ? WHERE id = ?",
+                    (new_field, row_id),
+                )
+                con.commit()
+                return True
+        except Exception as e:
+            print(f"[DB_ERROR] add_exemption(id={row_id}, {exempt_sub}): {e}")
+            return False
+
 # --- Reddit API Setup ---
 def setup_reddit():
     return praw.Reddit(

--- a/cross_sub_ban_bot.py
+++ b/cross_sub_ban_bot.py
@@ -16,9 +16,18 @@ from bot_config import (
     reddit
 )
 from log_utils import log_public_action, flush_views
+from health_utils import (
+    load_health,
+    save_health,
+    record_success,
+    record_failure,
+    summary as health_summary,
+)
+from modmail_utils import check_modmail
 
 # --- Global Cache ---
 BAN_CACHE = []
+HEALTH_STATE = None  # populated in main()
 
 # When DRY_RUN is set, propagation calls log intent but don't hit Reddit.
 DRY_RUN = os.environ.get('DRY_RUN', '').lower() in ('1', 'true', 'yes')
@@ -116,11 +125,23 @@ def sync_bans_from_sub(sub):
             elif log.action == "unbanuser":
                 handle_unban_action(user, user_lc, source, log.mod.name, sub, log.created_utc)
 
+        # Modlog walked successfully — record the sub as healthy
+        if HEALTH_STATE is not None:
+            record_success(HEALTH_STATE, sub)
+
     except prawcore.exceptions.Forbidden as e:
         print(f"[ERROR] Access forbidden for r/{sub}: {e}")
+        if HEALTH_STATE is not None:
+            record_failure(HEALTH_STATE, sub, f"Forbidden: {e}")
+    except prawcore.exceptions.NotFound as e:
+        print(f"[ERROR] NotFound for r/{sub}: {e}")
+        if HEALTH_STATE is not None:
+            record_failure(HEALTH_STATE, sub, f"NotFound: {e}")
     except Exception as e:
         print(f"[ERROR] Failed to process r/{sub}: {e}")
         traceback.print_exc()
+        if HEALTH_STATE is not None:
+            record_failure(HEALTH_STATE, sub, e)
 
 def handle_unban_action(user, user_lc, source, mod, sub, timestamp):
     """Process an unban action: forgive in DB, propagate the unban."""
@@ -179,10 +200,13 @@ def handle_ban_action(user, user_lc, source, mod, sub, timestamp, log_id):
 
 def main():
     """Main bot execution function."""
+    global HEALTH_STATE
     print("="*60)
     print("Cross-Sub Ban Bot - SQLite Edition")
     print(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     print("="*60)
+
+    HEALTH_STATE = load_health()
 
     try:
         print("\n[PHASE 1] Loading Data")
@@ -192,6 +216,17 @@ def main():
         for sub in TRUSTED_SUBS:
             sync_bans_from_sub(sub)
 
+        print("\n[PHASE 2.5] Checking Modmail for /xsub commands")
+        try:
+            check_modmail(
+                health_state=HEALTH_STATE,
+                dry_run=DRY_RUN,
+                propagate_unban=apply_unban_across_network,
+            )
+        except Exception as e:
+            print(f"[ERROR] Modmail check raised: {e}")
+            traceback.print_exc()
+
         print("\n[PHASE 3] Database Maintenance")
         deleted_count = database.cleanup_old_records(ROW_RETENTION_DAYS)
         if deleted_count > 0:
@@ -200,6 +235,10 @@ def main():
         print("\n[PHASE 4] Refreshing public log views")
         flush_views()
 
+        print("\n[PHASE 5] Health summary")
+        health_summary(HEALTH_STATE)
+        save_health(HEALTH_STATE)
+
         print("\n[SUCCESS] Bot execution completed successfully!")
 
     except KeyboardInterrupt:
@@ -207,6 +246,12 @@ def main():
     except Exception as e:
         print(f"\n[CRITICAL ERROR] Bot execution failed: {e}")
         traceback.print_exc()
+        # Try to persist whatever health info we have, even on partial failure
+        if HEALTH_STATE is not None:
+            try:
+                save_health(HEALTH_STATE)
+            except Exception:
+                pass
 
 if __name__ == "__main__":
     main()

--- a/health_utils.py
+++ b/health_utils.py
@@ -1,0 +1,102 @@
+"""
+Per-sub access health tracking.
+
+Writes/reads bot_health.json to track which trusted subs the bot can
+successfully read modlogs for. Emits clear log lines on state changes:
+
+  [HEALTH-ALERT]            sub flipped from healthy to failing
+  [HEALTH-RECOVERY]         sub recovered after previous failures
+  [HEALTH-ALERT-PERSISTENT] sub has been failing for N runs (escalation)
+  [HEALTH-SUMMARY]          end-of-run rollup
+
+The structured file makes the regression that bit us (silent loss of
+mod permission on r/floridapanthers + r/caps for ~10 months) detectable
+on the very next run instead of whenever someone notices the public log
+has gone quiet.
+"""
+import json
+import os
+from datetime import datetime, timezone
+
+HEALTH_FILE = "bot_health.json"
+
+# Cron is every 20 min. Escalate at ~1h, ~4h, ~24h of continuous failures.
+_ESCALATION_RUNS = {3, 12, 72}
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def load_health():
+    """Load existing health state, or return a fresh skeleton."""
+    if not os.path.exists(HEALTH_FILE):
+        return {"subs": {}, "last_run": None}
+    try:
+        with open(HEALTH_FILE) as f:
+            data = json.load(f)
+        # Defensive: ensure expected shape
+        data.setdefault("subs", {})
+        data.setdefault("last_run", None)
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"[HEALTH-WARN] Could not parse {HEALTH_FILE} ({e}); starting fresh.")
+        return {"subs": {}, "last_run": None}
+
+
+def save_health(state):
+    """Persist current state. Bumps last_run timestamp."""
+    state["last_run"] = _now()
+    try:
+        with open(HEALTH_FILE, "w") as f:
+            json.dump(state, f, indent=2, sort_keys=True)
+    except OSError as e:
+        print(f"[HEALTH-ERROR] Could not write {HEALTH_FILE}: {e}")
+
+
+def record_success(state, sub):
+    """Mark a sub as successfully accessed this run."""
+    s = state["subs"].setdefault(sub, {"consecutive_failures": 0})
+    was_failing = s.get("consecutive_failures", 0) > 0
+    s["last_ok"] = _now()
+    s["consecutive_failures"] = 0
+    s.pop("last_error", None)
+    if was_failing:
+        print(f"[HEALTH-RECOVERY] r/{sub} is healthy again after previous failures.")
+
+
+def record_failure(state, sub, error):
+    """Mark a sub as failing and emit an alert on transition or escalation."""
+    s = state["subs"].setdefault(sub, {"consecutive_failures": 0})
+    s["last_failure"] = _now()
+    s["last_error"] = str(error)[:200]
+    s["consecutive_failures"] = s.get("consecutive_failures", 0) + 1
+
+    n = s["consecutive_failures"]
+    if n == 1:
+        print(f"[HEALTH-ALERT] r/{sub} just started failing: {s['last_error']}")
+    elif n in _ESCALATION_RUNS:
+        approx_hours = n * 20 // 60
+        print(
+            f"[HEALTH-ALERT-PERSISTENT] r/{sub} has failed {n} consecutive runs "
+            f"(~{approx_hours}h): {s['last_error']}"
+        )
+
+
+def summary(state):
+    """Print a one-line rollup of the health state."""
+    subs = state.get("subs", {})
+    if not subs:
+        print("[HEALTH-SUMMARY] No subs tracked yet.")
+        return
+    failing = sorted(
+        sub for sub, s in subs.items() if s.get("consecutive_failures", 0) > 0
+    )
+    total = len(subs)
+    if failing:
+        print(
+            f"[HEALTH-SUMMARY] {total - len(failing)}/{total} subs healthy. "
+            f"Failing: {', '.join('r/' + s for s in failing)}"
+        )
+    else:
+        print(f"[HEALTH-SUMMARY] {total}/{total} subs healthy.")

--- a/modmail_utils.py
+++ b/modmail_utils.py
@@ -1,67 +1,361 @@
+"""
+Modmail command handler for the Cross-Sub Ban Pact bot.
+
+Listens for these commands as the latest mod-authored message in a
+modmail thread (state="new") on each trusted sub:
+
+  /xsub help                  -> static reference card
+  /xsub status u/<username>   -> facts from the bans DB (any trusted-sub mod)
+  /xsub pardon u/<username>   -> forgive + propagate unban (origin-sub mods only)
+  /xsub exempt u/<username>   -> exempt user from bans in this sub only
+
+Behaviour notes:
+- The bot will not reply twice to the same conversation (it checks for
+  any prior message authored by itself). A new mod message after a bot
+  reply will be treated as a fresh request.
+- /xsub pardon now also propagates the unban across the network. The
+  pre-Sheets-migration version only flipped the override flag, which
+  left users still banned on every other sub. Mods reasonably expect
+  pardon to mean "undo + prevent re-ban".
+- Modmail iteration failures are caught per-sub and recorded against
+  the health tracker so they surface alongside modlog access drift.
+"""
 from datetime import datetime
-import time
-from bot_config import sheet, reddit, TRUSTED_SUBS
-from core_utils import is_mod  # ensure this exists
+from bot_config import database, reddit, TRUSTED_SUBS
+from core_utils import is_mod
+from log_utils import log_public_action
+import os
+import prawcore
 
-def check_modmail():
-    print("[STEP] Checking for pardon and exemption messages...")
-    for sub in TRUSTED_SUBS:
-        print(f"[MODMAIL] Reading modmail for r/{sub}...")
-        try:
-            sr = reddit.subreddit(sub)
-            for state in ("new", "mod"):
-                for convo in sr.modmail.conversations(state=state):
-                    if not convo.messages:
-                        continue
-                    last = convo.messages[-1]
-                    body = getattr(last, 'body_markdown', '').strip()
-                    sender = getattr(last.author, 'name', '').lower()
-                    if not sender or not body:
-                        continue
-                    if not is_mod(sr, sender):
-                        continue
+# Cap how many recent convos we look at per sub per run, so a long modmail
+# history doesn't make every cron tick expensive.
+_MAX_CONVOS_PER_SUB = 25
 
-                    body_l = body.lower()
-                    parts = body_l.split()
-                    if body_l.startswith('/xsub pardon') and len(parts) >= 3:
-                        user = parts[2].lstrip('u/').strip()
-                        # Verify user was banned in this sub
-                        records = sheet.get_all_records()
-                        matched = next((r for r in records if r.get('Username', '').lower() == user.lower()), None)
-                        if matched and matched.get('SourceSub', '').lower() == sub.lower():
-                            apply_override(user, sender, sub)
-                            convo.reply(body=f"✅ u/{user} has been forgiven and will not be banned.")
-                        else:
-                            print(f"[WARN] Mod u/{sender} tried to pardon u/{user}, but ban was not from r/{sub}")
-                            convo.reply(f"⚠️ Can't pardon u/{user} — they were not banned in r/{sub}.")
+_HELP_TEXT = (
+    "**Cross-Sub Ban Pact Bot — Help**\n\n"
+    "Send these commands as a modmail to me from your sub. I check "
+    "modmail every 20 minutes.\n\n"
+    "    /xsub help                 — this message\n"
+    "    /xsub status u/username    — show this user's status across the network\n"
+    "    /xsub pardon u/username    — forgive + unban a user (origin-sub mods only)\n"
+    "    /xsub exempt u/username    — exempt this user from bans in your sub only\n\n"
+    "The pact triggers on bans whose reason is exactly "
+    "**Auto XSub Pact Ban**.\n\n"
+    "Public log: https://re-verse.github.io/cross_sub_ban_bot/public_ban_log.html"
+)
 
-                    elif body_l.startswith('/xsub exempt') and len(parts) >= 3:
-                        user = parts[2].lstrip('u/').strip()
-                        if apply_exemption(user, sub):
-                            convo.reply(body=f"✅ u/{user} has been exempted from bans in r/{sub}.")
-        except Exception as e:
-            print(f"[WARN] Could not check modmail for r/{sub}: {e}")
 
-def apply_override(username, moderator, modsub):
-    records = sheet.get_all_records()
-    for i, r in enumerate(records, start=2):
-        if r.get('Username', '').lower() == username.lower():
-            sheet.update_cell(i, 5, 'yes')
-            sheet.update_cell(i, 7, moderator)
-            sheet.update_cell(i, 8, modsub)
-            return True
-    now = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
-    sheet.append_row([username, 'manual', '', now, 'yes', '', moderator, modsub, ''])
-    return True
+def _bot_username():
+    """Return the bot's own Reddit username (lowercased) for self-detection."""
+    name = os.environ.get("REDDIT_USERNAME", "")
+    if name:
+        return name.lower()
+    try:
+        return reddit.user.me().name.lower()
+    except Exception:
+        return ""
 
-def apply_exemption(username, modsub):
-    records = sheet.get_all_records()
-    for i, r in enumerate(records, start=2):
-        if r.get('Username', '').lower() == username.lower():
-            current = str(r.get('ExemptSubs', '')).lower()
-            parts = {p.strip() for p in current.split(',') if p.strip()}
-            parts.add(modsub.lower())
-            new_field = ', '.join(sorted(parts))
-            sheet.update_cell(i, 10, new_field)
+
+def _bot_already_replied(convo, bot_name):
+    """Skip convos where we've already responded to avoid reply loops."""
+    if not bot_name:
+        return False
+    for m in convo.messages:
+        author = getattr(m.author, "name", "") or ""
+        if author.lower() == bot_name:
             return True
     return False
+
+
+def _parse_username(token):
+    """Strip a leading u/ or /u/ off a username token, return lowercased."""
+    t = token.strip().lstrip("/")
+    if t.lower().startswith("u/"):
+        t = t[2:]
+    return t.strip()
+
+
+def check_modmail(health_state=None, dry_run=False, propagate_unban=None):
+    """
+    Walk modmail on each trusted sub and act on /xsub commands.
+
+    health_state: optional dict from health_utils.load_health() — if passed,
+        modmail-access failures will be recorded against the per-sub tracker
+        so persistent issues surface in [HEALTH-ALERT-PERSISTENT] lines.
+    dry_run: if True, log intent but do not reply, mutate the DB, or
+        propagate any unbans. Mirrors the DRY_RUN gate in the main bot.
+    propagate_unban: optional callable(username, source_sub) used by
+        /xsub pardon to apply the unban across the trusted-sub network.
+        Passed in by the main bot so the propagation path is shared with
+        the modlog-driven unban handler.
+    """
+    print("[MODMAIL] Checking for /xsub commands...")
+    bot_name = _bot_username()
+
+    for sub in TRUSTED_SUBS:
+        try:
+            sr = reddit.subreddit(sub)
+            seen = 0
+            for convo in sr.modmail.conversations(state="new"):
+                seen += 1
+                if seen > _MAX_CONVOS_PER_SUB:
+                    break
+                _handle_convo(
+                    convo, sr, sub, bot_name,
+                    dry_run=dry_run,
+                    propagate_unban=propagate_unban,
+                )
+        except prawcore.exceptions.Forbidden as e:
+            print(f"[MODMAIL-WARN] Forbidden on r/{sub}: {e}")
+            if health_state is not None:
+                from health_utils import record_failure
+                record_failure(health_state, f"{sub}:modmail", e)
+        except prawcore.exceptions.NotFound as e:
+            print(f"[MODMAIL-WARN] NotFound on r/{sub}: {e}")
+            if health_state is not None:
+                from health_utils import record_failure
+                record_failure(health_state, f"{sub}:modmail", e)
+        except Exception as e:
+            print(f"[MODMAIL-ERROR] r/{sub}: {e}")
+
+
+def _handle_convo(convo, sr, sub, bot_name, dry_run=False, propagate_unban=None):
+    """Process a single conversation if it looks like a fresh /xsub command."""
+    if not convo.messages:
+        return
+    if _bot_already_replied(convo, bot_name):
+        return
+
+    last = convo.messages[-1]
+    body = (getattr(last, "body_markdown", "") or "").strip()
+    sender = (getattr(last.author, "name", "") or "").lower()
+    if not sender or not body:
+        return
+    if sender == bot_name:
+        return  # last message was ours; nothing to act on
+    if not is_mod(sr, sender):
+        return
+
+    body_l = body.lower()
+    # Be tolerant of leading whitespace / quoting characters
+    body_l = body_l.lstrip("> ").strip()
+    if not body_l.startswith("/xsub"):
+        return
+
+    parts = body_l.split()
+    if len(parts) < 2:
+        return
+    cmd = parts[1]
+
+    if cmd == "help":
+        _reply(convo, _HELP_TEXT, dry_run=dry_run, sub=sub, sender=sender, cmd="help")
+        return
+
+    if len(parts) < 3:
+        _reply(
+            convo,
+            f"⚠️ `/xsub {cmd}` needs a username. Try `/xsub help` for the full list.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd=cmd,
+        )
+        return
+
+    user = _parse_username(parts[2])
+    if not user:
+        _reply(
+            convo,
+            "⚠️ Could not parse the username. Format: `/xsub <cmd> u/username`",
+            dry_run=dry_run, sub=sub, sender=sender, cmd=cmd,
+        )
+        return
+
+    if cmd == "status":
+        _handle_status(convo, user, dry_run=dry_run, sub=sub, sender=sender)
+    elif cmd == "pardon":
+        _handle_pardon(
+            convo, user, sub, sender,
+            dry_run=dry_run, propagate_unban=propagate_unban,
+        )
+    elif cmd == "exempt":
+        _handle_exempt(convo, user, sub, sender, dry_run=dry_run)
+    else:
+        _reply(
+            convo,
+            f"⚠️ Unknown command `/xsub {cmd}`. Try `/xsub help`.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd=cmd,
+        )
+
+
+def _handle_status(convo, user, dry_run, sub, sender):
+    rows = database.find_user_records(user)
+    if not rows:
+        _reply(
+            convo,
+            f"📭 No record of u/{user} in the pact database.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd="status",
+        )
+        return
+
+    # Pick the most informative row to summarise (any forgiven row wins;
+    # otherwise the most recent insert).
+    forgiven_row = next(
+        (r for r in rows if (r.get("manual_override") or "").lower() == "yes"),
+        None,
+    )
+    primary = forgiven_row or rows[0]
+    src = primary.get("source_sub") or "?"
+    when = primary.get("timestamp") or "?"
+    forgiven = (primary.get("manual_override") or "").lower() == "yes"
+    forgive_by = primary.get("moderator_name") or ""
+    forgive_sub = primary.get("mod_sub") or ""
+    forgive_when = primary.get("forgive_timestamp") or ""
+    exempt = (primary.get("exempt_subs") or "").strip()
+
+    lines = [f"**Status for u/{user}**", ""]
+    lines.append(f"- Origin sub: {src}")
+    lines.append(f"- First recorded: {when}")
+    if forgiven:
+        details = []
+        if forgive_by:
+            details.append(f"by u/{forgive_by}")
+        if forgive_sub:
+            details.append(f"in {forgive_sub}")
+        if forgive_when:
+            details.append(f"on {forgive_when}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        lines.append(f"- Forgiven: ✅ yes{suffix}")
+    else:
+        lines.append("- Forgiven: ❌ no — currently banned across the pact network")
+    if exempt:
+        lines.append(f"- Exempt in: {exempt}")
+    if len(rows) > 1:
+        lines.append(f"- Records in DB: {len(rows)}")
+
+    _reply(
+        convo, "\n".join(lines),
+        dry_run=dry_run, sub=sub, sender=sender, cmd="status",
+    )
+
+
+def _handle_pardon(convo, user, sub, sender, dry_run, propagate_unban):
+    sub_lc = sub.lower()
+    rows = database.find_user_records(user)
+    matched = next(
+        (
+            r for r in rows
+            if (r.get("source_sub") or "").lower().lstrip("r/").strip("/") == sub_lc
+        ),
+        None,
+    )
+    if not matched:
+        _reply(
+            convo,
+            f"⚠️ Cannot pardon u/{user} — they were not banned originally in r/{sub}. "
+            "Pardons must come from the origin-sub mod team.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd="pardon",
+        )
+        return
+
+    if (matched.get("manual_override") or "").lower() == "yes":
+        _reply(
+            convo,
+            f"ℹ️ u/{user} was already forgiven. No further action taken.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd="pardon",
+        )
+        return
+
+    source_sub = matched.get("source_sub")
+    when = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+
+    if dry_run:
+        print(
+            f"[DRY-RUN][MODMAIL-PARDON] would pardon u/{user} (source {source_sub}) "
+            f"by u/{sender} from r/{sub} and propagate unban"
+        )
+        return
+
+    if not database.apply_pardon(user, source_sub, sender, sub, when):
+        _reply(
+            convo,
+            f"❌ Internal error pardoning u/{user}; check the bot logs.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd="pardon",
+        )
+        return
+
+    print(
+        f"[MODMAIL-PARDON] u/{user} pardoned by u/{sender} from r/{sub} "
+        f"(source: {source_sub})"
+    )
+    log_public_action(
+        "FORGIVEN", user, sub, source_sub=source_sub,
+        actor=f"{sender} (modmail-pardon)",
+    )
+
+    if propagate_unban is not None:
+        try:
+            propagate_unban(user, source_sub)
+        except Exception as e:
+            print(f"[MODMAIL-PARDON-WARN] propagation raised: {e}")
+
+    _reply(
+        convo,
+        f"✅ u/{user} has been forgiven and unbanned across the pact network.",
+        dry_run=False, sub=sub, sender=sender, cmd="pardon",
+    )
+
+
+def _handle_exempt(convo, user, sub, sender, dry_run):
+    sub_lc = sub.lower()
+    rows = database.find_user_records(user)
+
+    if dry_run:
+        print(
+            f"[DRY-RUN][MODMAIL-EXEMPT] would exempt u/{user} in r/{sub} "
+            f"(requested by u/{sender})"
+        )
+        return
+
+    if not rows:
+        # No DB row to attach the exemption to. Be honest about the limitation
+        # rather than silently dropping it.
+        _reply(
+            convo,
+            f"ℹ️ u/{user} is not currently in the pact DB, so there's nothing to "
+            f"exempt them from. If they get banned via the pact later, "
+            f"send `/xsub exempt u/{user}` again.",
+            dry_run=False, sub=sub, sender=sender, cmd="exempt",
+        )
+        return
+
+    updated = 0
+    for r in rows:
+        if database.add_exemption(r["id"], sub_lc):
+            updated += 1
+
+    if updated:
+        print(
+            f"[MODMAIL-EXEMPT] u/{user} exempted in r/{sub} by u/{sender} "
+            f"({updated} row(s) updated)"
+        )
+        _reply(
+            convo,
+            f"✅ u/{user} is now exempt from pact bans in r/{sub}.",
+            dry_run=False, sub=sub, sender=sender, cmd="exempt",
+        )
+    else:
+        _reply(
+            convo,
+            f"❌ Failed to record exemption for u/{user}; check the bot logs.",
+            dry_run=False, sub=sub, sender=sender, cmd="exempt",
+        )
+
+
+def _reply(convo, body, dry_run, sub, sender, cmd):
+    """Reply to a modmail convo, gated by dry_run. Always logs the intent."""
+    if dry_run:
+        print(f"[DRY-RUN][MODMAIL-REPLY] r/{sub} u/{sender} cmd={cmd}: would reply")
+        return
+    try:
+        convo.reply(body=body)
+        print(f"[MODMAIL-REPLY] r/{sub} u/{sender} cmd={cmd}: replied")
+    except Exception as e:
+        print(f"[MODMAIL-ERROR] r/{sub} u/{sender} cmd={cmd}: reply failed: {e}")


### PR DESCRIPTION
## Summary

Adds two pieces of work that follow on from PR #8:

1. **`/xsub help|status|pardon|exempt` modmail commands** — fully wired up and SQLite-backed. The Sheets-based `modmail_utils.py` has been broken since the 2025-07-26 SQLite migration and was never invoked from the running bot. This rewrites it from scratch, ports it to the new DB layer, and wires it into a new PHASE 2.5 in the main run loop.

2. **Per-sub access health tracker** (`bot_health.json`) — records modlog (and modmail) access success/failure per sub across runs and emits structured alerts on transitions:
   - `[HEALTH-ALERT]` on first failure
   - `[HEALTH-RECOVERY]` when a sub comes back
   - `[HEALTH-ALERT-PERSISTENT]` at 3 / 12 / 72 consecutive failures (~1h, ~4h, ~24h)
   - `[HEALTH-SUMMARY]` at end of every run

   The regression that bit us last summer (silent loss of mod permission on r/floridapanthers + r/caps for ~10 months) would be visible on the very next run instead of whenever someone notices the public log has gone quiet.

## Files

- `modmail_utils.py` — full rewrite, SQLite-backed, with bot self-author check to prevent reply loops, per-sub modmail iteration cap, and health tracker integration. **`/xsub pardon` now also propagates the unban across the network** — the pre-migration version only flipped the override flag, leaving users banned everywhere except the origin sub. Mods reasonably expect pardon to mean undo + prevent re-ban.
- `health_utils.py` — new module, ~100 lines.
- `bot_config.py` — three new `Database` methods: `find_user_records`, `apply_pardon`, `add_exemption`. Unit-tested locally against an in-memory schema mirror.
- `cross_sub_ban_bot.py` — new PHASE 2.5 (modmail) and PHASE 5 (health summary). `sync_bans_from_sub` records success/failure against the tracker including a NotFound branch so the floridapanthers/caps situation gets escalated. Health state persists on critical-error exit so partial-run information survives.
- `run_bot.yml` — stage `bot_health.json` so the tracker persists across cron runs.

## Validation

Dry-run executed on this branch (run 25638236182, 40s):

```
[PHASE 1] Loading Data
[PHASE 2] Syncing Bans from Source Subreddits
  [SYNC] r/habs, r/leafs, r/winnipegjets, r/goldenknights, r/anaheimducks, r/ottawasenators, r/xsubpacttest1 — OK
  [ERROR] NotFound for r/floridapanthers
  [HEALTH-ALERT] r/floridapanthers just started failing
  [ERROR] NotFound for r/caps
  [HEALTH-ALERT] r/caps just started failing
[PHASE 2.5] Checking Modmail for /xsub commands
  [MODMAIL] walked all subs
  [MODMAIL-WARN] Forbidden (403) on r/floridapanthers and r/caps
[PHASE 3] Database Maintenance
[PHASE 4] Refreshing public log views
[PHASE 5] Health summary
  [HEALTH-SUMMARY] 7/11 subs healthy. Failing: r/caps, r/caps:modmail, r/floridapanthers, r/floridapanthers:modmail
[SUCCESS] Bot execution completed successfully!
```

DRY_RUN gated all reply attempts, DB mutations, and unban propagation — no mutations on Reddit's side, no DB writes.

## Followups, not blocking

- `super.py` still references the old Sheets API and `SHEET_CACHE`. The `/xsub super` admin commands are rare-use and the bot is functional without them. Port whenever convenient.
- Re-mod `xsub-pact-bot` in r/floridapanthers and r/caps. The new health alerts will go quiet once that's done; until then they'll just be steady-state noise (which is the correct signal — those subs ARE failing).
- Dead-code cleanup: `main.py`, `bot_config_sqlite.py`, `db_utils.py`, `config_sqlite.json`, `config_original.json`, the four test-scaffold workflows (`debug.yml`, `manual-run.yml`, `manual-test.yml`, `simple-trigger.yml`, `test-sqlite.yml`).

Authored with Claude assistance.