### PR TITLE
Add DM alerts, /xsub history, recent-activity tab

### DIFF
--- a/bot_config.py
+++ b/bot_config.py
@@ -192,3 +192,26 @@ def setup_reddit():
 # --- Instantiate APIs ---
 reddit = setup_reddit()
 database = Database(SQLITE_DB_PATH)
+
+# --- Owner Alerts ---
+OWNER_USERNAME = config.get("OWNER_USERNAME", "re-verse")
+
+
+def notify_owner(subject, body, dry_run=False):
+    """
+    Send a DM to the bot owner. Used by the health tracker to flag
+    sub-level access regressions in near-real-time.
+
+    Returns True on success (or dry-run skip), False on error. Failures
+    are logged but never raised — alerting must not break the cron tick.
+    """
+    if dry_run:
+        print(f"[DRY-RUN][NOTIFY-OWNER] would DM u/{OWNER_USERNAME}: {subject}")
+        return True
+    try:
+        reddit.redditor(OWNER_USERNAME).message(subject=subject, message=body)
+        print(f"[NOTIFY-OWNER] DM sent to u/{OWNER_USERNAME}: {subject}")
+        return True
+    except Exception as e:
+        print(f"[NOTIFY-OWNER-ERROR] Could not DM u/{OWNER_USERNAME}: {e}")
+        return False

--- a/cross_sub_ban_bot.py
+++ b/cross_sub_ban_bot.py
@@ -13,7 +13,8 @@ from bot_config import (
     ROW_RETENTION_DAYS,
     TRUSTED_SUBS,
     database,
-    reddit
+    reddit,
+    notify_owner,
 )
 from log_utils import log_public_action, flush_views
 from health_utils import (
@@ -22,6 +23,7 @@ from health_utils import (
     record_success,
     record_failure,
     summary as health_summary,
+    dispatch_alerts,
 )
 from modmail_utils import check_modmail
 from inbox_utils import check_dm_inbox
@@ -245,6 +247,11 @@ def main():
 
         print("\n[PHASE 5] Health summary")
         health_summary(HEALTH_STATE)
+        try:
+            dispatch_alerts(HEALTH_STATE, notify_owner, dry_run=DRY_RUN)
+        except Exception as e:
+            print(f"[ERROR] dispatch_alerts raised: {e}")
+            traceback.print_exc()
         save_health(HEALTH_STATE)
 
         print("\n[SUCCESS] Bot execution completed successfully!")

--- a/health_utils.py
+++ b/health_utils.py
@@ -9,47 +9,78 @@ successfully read modlogs for. Emits clear log lines on state changes:
   [HEALTH-ALERT-PERSISTENT] sub has been failing for N runs (escalation)
   [HEALTH-SUMMARY]          end-of-run rollup
 
-The structured file makes the regression that bit us (silent loss of
-mod permission on r/floridapanthers + r/caps for ~10 months) detectable
-on the very next run instead of whenever someone notices the public log
-has gone quiet.
+Alertable transitions are also collected into state["pending_events"]
+and drained by dispatch_alerts() at end-of-run, which DMs the bot owner
+via bot_config.notify_owner.
+
+Alerting policy (configured by user):
+- Alert on first failure of a sub (consecutive_failures transitions
+  from 0 -> 1) and on each escalation threshold (3 / 12 / 72 runs).
+- Recoveries are NOT alerted. They're visible in the log line and in
+  the next [HEALTH-SUMMARY], which is enough.
+- Throttle: a given (sub, reason) combination won't re-alert within
+  THROTTLE_HOURS regardless of how many escalation marks pass.
 """
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 HEALTH_FILE = "bot_health.json"
 
 # Cron is every 20 min. Escalate at ~1h, ~4h, ~24h of continuous failures.
 _ESCALATION_RUNS = {3, 12, 72}
 
+# Don't re-alert on the same (sub, event_type) inside this window.
+THROTTLE_HOURS = 24
+
 
 def _now():
-    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(timezone.utc)
+
+
+def _now_iso():
+    return _now().isoformat(timespec="seconds")
 
 
 def load_health():
     """Load existing health state, or return a fresh skeleton."""
     if not os.path.exists(HEALTH_FILE):
-        return {"subs": {}, "last_run": None}
+        return _fresh_state()
     try:
         with open(HEALTH_FILE) as f:
             data = json.load(f)
         # Defensive: ensure expected shape
         data.setdefault("subs", {})
         data.setdefault("last_run", None)
+        data.setdefault("alert_history", {})
+        # pending_events is rebuilt each run, never persisted
+        data["pending_events"] = []
         return data
     except (json.JSONDecodeError, OSError) as e:
         print(f"[HEALTH-WARN] Could not parse {HEALTH_FILE} ({e}); starting fresh.")
-        return {"subs": {}, "last_run": None}
+        return _fresh_state()
+
+
+def _fresh_state():
+    return {
+        "subs": {},
+        "last_run": None,
+        "alert_history": {},
+        "pending_events": [],
+    }
 
 
 def save_health(state):
-    """Persist current state. Bumps last_run timestamp."""
-    state["last_run"] = _now()
+    """Persist current state. Bumps last_run timestamp. Drops transient fields."""
+    state["last_run"] = _now_iso()
+    to_save = {
+        "subs": state.get("subs", {}),
+        "last_run": state["last_run"],
+        "alert_history": state.get("alert_history", {}),
+    }
     try:
         with open(HEALTH_FILE, "w") as f:
-            json.dump(state, f, indent=2, sort_keys=True)
+            json.dump(to_save, f, indent=2, sort_keys=True)
     except OSError as e:
         print(f"[HEALTH-ERROR] Could not write {HEALTH_FILE}: {e}")
 
@@ -58,7 +89,7 @@ def record_success(state, sub):
     """Mark a sub as successfully accessed this run."""
     s = state["subs"].setdefault(sub, {"consecutive_failures": 0})
     was_failing = s.get("consecutive_failures", 0) > 0
-    s["last_ok"] = _now()
+    s["last_ok"] = _now_iso()
     s["consecutive_failures"] = 0
     s.pop("last_error", None)
     if was_failing:
@@ -66,21 +97,33 @@ def record_success(state, sub):
 
 
 def record_failure(state, sub, error):
-    """Mark a sub as failing and emit an alert on transition or escalation."""
+    """Mark a sub as failing and queue an alert event on transition/escalation."""
     s = state["subs"].setdefault(sub, {"consecutive_failures": 0})
-    s["last_failure"] = _now()
+    s["last_failure"] = _now_iso()
     s["last_error"] = str(error)[:200]
     s["consecutive_failures"] = s.get("consecutive_failures", 0) + 1
 
     n = s["consecutive_failures"]
     if n == 1:
         print(f"[HEALTH-ALERT] r/{sub} just started failing: {s['last_error']}")
+        _queue_event(state, sub, "first_failure", n, s["last_error"])
     elif n in _ESCALATION_RUNS:
         approx_hours = n * 20 // 60
         print(
             f"[HEALTH-ALERT-PERSISTENT] r/{sub} has failed {n} consecutive runs "
             f"(~{approx_hours}h): {s['last_error']}"
         )
+        _queue_event(state, sub, f"escalation_{n}", n, s["last_error"])
+
+
+def _queue_event(state, sub, event_type, n_failures, last_error):
+    """Append an alertable event to the per-run queue."""
+    state.setdefault("pending_events", []).append({
+        "sub": sub,
+        "event_type": event_type,
+        "n_failures": n_failures,
+        "last_error": last_error,
+    })
 
 
 def summary(state):
@@ -100,3 +143,89 @@ def summary(state):
         )
     else:
         print(f"[HEALTH-SUMMARY] {total}/{total} subs healthy.")
+
+
+def dispatch_alerts(state, notify_func, dry_run=False):
+    """
+    Drain pending_events, apply the THROTTLE_HOURS suppression, and send
+    a single consolidated DM if anything survives.
+
+    notify_func: callable matching bot_config.notify_owner signature
+        (subject, body, dry_run=False) -> bool. Injected so this module
+        stays free of bot_config imports (avoids a cycle).
+    """
+    events = state.get("pending_events", [])
+    if not events:
+        return
+
+    history = state.setdefault("alert_history", {})
+    cutoff = _now() - timedelta(hours=THROTTLE_HOURS)
+
+    surviving = []
+    for ev in events:
+        key = f"{ev['sub']}::{ev['event_type']}"
+        last_sent = _parse_iso(history.get(key))
+        if last_sent and last_sent > cutoff:
+            print(
+                f"[ALERT-THROTTLED] {key} suppressed "
+                f"(last sent {history[key]}, within {THROTTLE_HOURS}h window)"
+            )
+            continue
+        surviving.append(ev)
+
+    if not surviving:
+        return
+
+    subject, body = _format_alert(surviving)
+    if notify_func(subject, body, dry_run=dry_run):
+        # Record-as-sent even in dry-run, so dry-run output reflects what
+        # production would send. The throttle window is still meaningful
+        # because the same json gets committed back to the repo.
+        if not dry_run:
+            stamp = _now_iso()
+            for ev in surviving:
+                key = f"{ev['sub']}::{ev['event_type']}"
+                history[key] = stamp
+
+
+def _parse_iso(s):
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _format_alert(events):
+    """Build (subject, body) for a consolidated alert DM."""
+    if len(events) == 1:
+        ev = events[0]
+        subject = f"[xsub-pact-bot] r/{ev['sub']} {_describe(ev['event_type'])}"
+    else:
+        subject = f"[xsub-pact-bot] {len(events)} sub health alerts"
+
+    lines = ["The pact bot health tracker flagged the following:", ""]
+    for ev in events:
+        lines.append(
+            f"- r/{ev['sub']}: {_describe(ev['event_type'])} "
+            f"({ev['n_failures']} consecutive failure"
+            f"{'s' if ev['n_failures'] != 1 else ''})"
+        )
+        lines.append(f"    last error: {ev['last_error']}")
+    lines.append("")
+    lines.append(
+        f"Throttled to one alert per (sub, event) per {THROTTLE_HOURS}h. "
+        "See bot_health.json on main for full state."
+    )
+    return subject, "\n".join(lines)
+
+
+def _describe(event_type):
+    if event_type == "first_failure":
+        return "started failing"
+    if event_type.startswith("escalation_"):
+        n = int(event_type.split("_")[1])
+        approx_hours = n * 20 // 60
+        return f"has failed {n} consecutive runs (~{approx_hours}h)"
+    return event_type

--- a/inbox_utils.py
+++ b/inbox_utils.py
@@ -33,6 +33,7 @@ _HELP_TEXT = (
     "action is attributable to a specific mod team.\n\n"
     "    /xsub help                 — this message\n"
     "    /xsub status u/username    — show this user's status across the network\n"
+    "    /xsub history u/username   — chronological audit trail (modmail only)\n"
     "    /xsub pardon u/username    — forgive + unban a user (origin-sub mods only, modmail only)\n"
     "    /xsub exempt u/username    — exempt user from bans in your sub only (modmail only)\n\n"
     "The pact triggers on bans whose reason is exactly "
@@ -134,7 +135,7 @@ def check_dm_inbox(dry_run=False):
         if cmd == "help":
             reply_body = _HELP_TEXT
             log_tag = "help"
-        elif cmd in ("status", "pardon", "exempt"):
+        elif cmd in ("status", "history", "pardon", "exempt"):
             reply_body = (
                 f"ℹ️ `/xsub {cmd}` is only available via modmail to your own sub, "
                 "not via DM. This keeps every action attributable to a specific "

--- a/log_utils.py
+++ b/log_utils.py
@@ -21,6 +21,7 @@ PUBLIC_LOG_HTML = "public_ban_log.html"
 
 RECENT_DAYS = 30
 HTML_MAX_ROWS = 200
+HTML_RECENT_DAYS = 7  # default-tab cutoff in the HTML dashboard
 
 # Module-level flag: did this run actually log anything?
 _logged_this_run = False
@@ -114,23 +115,26 @@ def _write_markdown(recent, total):
 
 
 def _write_html(rows, total):
-    """Compact searchable table for GitHub Pages."""
+    """Compact searchable table for GitHub Pages with Recent (7d) / All tabs."""
     try:
         last_updated = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
-        # Headline stats
-        cutoff_dt = datetime.utcnow() - timedelta(days=RECENT_DAYS)
-        cutoff_s = cutoff_dt.strftime('%Y-%m-%d %H:%M:%S')
-        recent_count = sum(1 for e in rows if e.get('timestamp', '') >= cutoff_s)
-        bans_recent = sum(1 for e in rows if e.get('timestamp', '') >= cutoff_s and e.get('action') == 'BANNED')
-        unbans_recent = recent_count - bans_recent
+        cutoff_30d = (datetime.utcnow() - timedelta(days=RECENT_DAYS)).strftime('%Y-%m-%d %H:%M:%S')
+        cutoff_7d = (datetime.utcnow() - timedelta(days=HTML_RECENT_DAYS)).strftime('%Y-%m-%d %H:%M:%S')
+
+        recent_30d_count = sum(1 for e in rows if e.get('timestamp', '') >= cutoff_30d)
+        bans_30d = sum(1 for e in rows if e.get('timestamp', '') >= cutoff_30d and e.get('action') == 'BANNED')
+        unbans_30d = recent_30d_count - bans_30d
+        recent_7d_count = sum(1 for e in rows if e.get('timestamp', '') >= cutoff_7d)
 
         body_rows = []
         for e in rows:
             action = e.get('action', '')
             cls = 'banned' if action == 'BANNED' else 'unbanned'
+            ts = e.get('timestamp', '')
+            is_recent = '1' if ts >= cutoff_7d else '0'
             body_rows.append(
-                f'<tr class="{cls}">'
-                f'<td>{escape(e.get("timestamp", ""))}</td>'
+                f'<tr class="{cls}" data-recent="{is_recent}">'
+                f'<td>{escape(ts)}</td>'
                 f'<td>{escape(action)}</td>'
                 f'<td>u/{escape(e.get("username", ""))}</td>'
                 f'<td>r/{escape(e.get("subreddit", ""))}</td>'
@@ -155,6 +159,11 @@ def _write_html(rows, total):
   .stats {{ display: flex; gap: 1.5rem; margin-bottom: 1rem; flex-wrap: wrap; }}
   .stat {{ background: rgba(127,127,127,.08); padding: .5rem 1rem; border-radius: 6px; }}
   .stat strong {{ display: block; font-size: 1.4rem; }}
+  .tabs {{ display: flex; gap: .25rem; margin-bottom: .5rem; border-bottom: 1px solid rgba(127,127,127,.2); }}
+  .tab {{ padding: .5rem .9rem; cursor: pointer; border: none; background: none;
+         color: CanvasText; font: inherit; border-bottom: 2px solid transparent; }}
+  .tab[aria-selected="true"] {{ border-bottom-color: #36c; font-weight: 600; }}
+  .tab:hover {{ background: rgba(127,127,127,.06); }}
   input[type=search] {{ width: 100%; padding: .5rem .75rem; margin-bottom: 1rem;
                        border: 1px solid rgba(127,127,127,.3); border-radius: 6px;
                        background: Canvas; color: CanvasText; font: inherit; }}
@@ -165,6 +174,7 @@ def _write_html(rows, total):
   tr.banned td:nth-child(2) {{ color: #c33; }}
   tr.unbanned td:nth-child(2) {{ color: #2a8; }}
   tr.hidden {{ display: none; }}
+  .empty {{ color: #888; text-align: center; padding: 1.5rem; }}
   .footer {{ color: #888; font-size: .85rem; margin-top: 1.5rem; }}
   a {{ color: #36c; }}
 </style>
@@ -175,8 +185,14 @@ def _write_html(rows, total):
 
 <div class="stats">
   <div class="stat"><strong>{total}</strong>total actions</div>
-  <div class="stat"><strong>{bans_recent}</strong>bans, last {RECENT_DAYS}d</div>
-  <div class="stat"><strong>{unbans_recent}</strong>unbans, last {RECENT_DAYS}d</div>
+  <div class="stat"><strong>{recent_7d_count}</strong>last 7 days</div>
+  <div class="stat"><strong>{bans_30d}</strong>bans, last {RECENT_DAYS}d</div>
+  <div class="stat"><strong>{unbans_30d}</strong>unbans, last {RECENT_DAYS}d</div>
+</div>
+
+<div class="tabs" role="tablist">
+  <button class="tab" id="tab-recent" role="tab" aria-selected="true" aria-controls="rows">Recent ({HTML_RECENT_DAYS}d)</button>
+  <button class="tab" id="tab-all" role="tab" aria-selected="false" aria-controls="rows">All ({len(rows)})</button>
 </div>
 
 <input id="filter" type="search" placeholder="Filter by user, subreddit, action, source…">
@@ -186,9 +202,10 @@ def _write_html(rows, total):
     <tr><th>Timestamp (UTC)</th><th>Action</th><th>User</th><th>Subreddit</th><th>Source</th><th>Actor</th></tr>
   </thead>
   <tbody id="rows">
-    {''.join(body_rows) if body_rows else '<tr><td colspan="6" style="color:#888;text-align:center;padding:1rem;">No actions yet.</td></tr>'}
+    {''.join(body_rows) if body_rows else '<tr><td colspan="6" class="empty">No actions yet.</td></tr>'}
   </tbody>
 </table>
+<div id="empty-recent" class="empty" hidden>No actions in the last {HTML_RECENT_DAYS} days.</div>
 
 <div class="footer">
   Full audit trail: <a href="public_ban_log.json">public_ban_log.json</a> ·
@@ -199,12 +216,37 @@ def _write_html(rows, total):
 <script>
   const input = document.getElementById('filter');
   const rows = document.querySelectorAll('#rows tr');
-  input.addEventListener('input', () => {{
+  const tabRecent = document.getElementById('tab-recent');
+  const tabAll = document.getElementById('tab-all');
+  const emptyRecent = document.getElementById('empty-recent');
+  let scope = 'recent';
+
+  function apply() {{
     const q = input.value.toLowerCase().trim();
+    let shownInScope = 0;
     rows.forEach(r => {{
-      r.classList.toggle('hidden', q && !r.textContent.toLowerCase().includes(q));
+      const inScope = (scope === 'all') || r.dataset.recent === '1';
+      const matchesQuery = !q || r.textContent.toLowerCase().includes(q);
+      const show = inScope && matchesQuery;
+      r.classList.toggle('hidden', !show);
+      if (inScope) shownInScope++;
     }});
-  }});
+    if (emptyRecent) {{
+      emptyRecent.hidden = !(scope === 'recent' && shownInScope === 0);
+    }}
+  }}
+
+  function selectTab(which) {{
+    scope = which;
+    tabRecent.setAttribute('aria-selected', which === 'recent');
+    tabAll.setAttribute('aria-selected', which === 'all');
+    apply();
+  }}
+
+  tabRecent.addEventListener('click', () => selectTab('recent'));
+  tabAll.addEventListener('click', () => selectTab('all'));
+  input.addEventListener('input', apply);
+  apply();
 </script>
 </body>
 </html>

--- a/modmail_utils.py
+++ b/modmail_utils.py
@@ -41,6 +41,7 @@ _HELP_TEXT = (
     "attributable to a specific mod team.\n\n"
     "    /xsub help                 — this message\n"
     "    /xsub status u/username    — show this user's status across the network\n"
+    "    /xsub history u/username   — chronological audit trail for this user\n"
     "    /xsub pardon u/username    — forgive + unban a user (origin-sub mods only)\n"
     "    /xsub exempt u/username    — exempt this user from bans in your sub only\n\n"
     "The pact triggers on bans whose reason is exactly "
@@ -174,6 +175,8 @@ def _handle_convo(convo, sr, sub, bot_name, dry_run=False, propagate_unban=None)
 
     if cmd == "status":
         _handle_status(convo, user, dry_run=dry_run, sub=sub, sender=sender)
+    elif cmd == "history":
+        _handle_history(convo, user, dry_run=dry_run, sub=sub, sender=sender)
     elif cmd == "pardon":
         _handle_pardon(
             convo, user, sub, sender,
@@ -237,6 +240,51 @@ def _handle_status(convo, user, dry_run, sub, sender):
     _reply(
         convo, "\n".join(lines),
         dry_run=dry_run, sub=sub, sender=sender, cmd="status",
+    )
+
+
+def _handle_history(convo, user, dry_run, sub, sender):
+    """Render a chronological audit trail across all DB rows for this user."""
+    rows = database.find_user_records(user)
+    if not rows:
+        _reply(
+            convo,
+            f"📭 No record of u/{user} in the pact database.",
+            dry_run=dry_run, sub=sub, sender=sender, cmd="history",
+        )
+        return
+
+    # find_user_records returns most-recent-first; reverse for chronological.
+    events = []
+    exempt_lines = []
+    for r in reversed(rows):
+        ts = r.get("timestamp") or "?"
+        src = r.get("source_sub") or "?"
+        actor = r.get("moderator_name") or "?"
+        events.append(
+            f"- `{ts}`  **BANNED** in {src} by u/{actor}"
+        )
+        if (r.get("manual_override") or "").lower() == "yes":
+            f_ts = r.get("forgive_timestamp") or "?"
+            f_by = r.get("moderator_name") or "?"
+            f_sub = r.get("mod_sub") or "?"
+            events.append(
+                f"- `{f_ts}`  **FORGIVEN** by u/{f_by} (in {f_sub})"
+            )
+        ex = (r.get("exempt_subs") or "").strip()
+        if ex:
+            exempt_lines.append(f"  - from row in {src}: exempt in {ex}")
+
+    lines = [f"**Audit trail for u/{user}** ({len(rows)} DB row(s))", ""]
+    lines.extend(events)
+    if exempt_lines:
+        lines.append("")
+        lines.append("Current exemptions:")
+        lines.extend(exempt_lines)
+
+    _reply(
+        convo, "\n".join(lines),
+        dry_run=dry_run, sub=sub, sender=sender, cmd="history",
     )
 
 


### PR DESCRIPTION
## What

Three coherent additions that make the bot self-reporting without changing any propagation behavior:

### 1. Reddit DM alerts on health transitions
- New `notify_owner()` helper in `bot_config.py` (DMs u/re-verse via PRAW)
- `health_utils.dispatch_alerts()` drains queued transition events at end-of-run
- **Fires on:** first failure of a sub, and the three escalation marks (3 / 12 / 72 consecutive failures = ~1h / 4h / 24h)
- **Does NOT fire on:** recoveries (per chosen policy — the next HEALTH-SUMMARY shows the recovery anyway)
- **24h throttle** on `(sub, event_type)` — a sub that keeps failing won't spam past the four expected events
- `alert_history` persists in `bot_health.json`; `pending_events` is per-run only
- DRY_RUN gate honored — propagates through to notify_func, doesn't pollute alert_history

### 2. `/xsub history u/username` modmail command
- Chronological audit trail for a user: every BANNED + FORGIVEN with timestamps, mod, source sub, plus current exemptions
- Reuses existing `database.find_user_records` — no new SQLite work
- Same access model as `/xsub status` (any trusted-sub mod, via modmail)
- DM'd `/xsub history` gets a polite 'use modmail' redirect

### 3. Recent (7d) / All tabs in `public_ban_log.html`
- Default tab on page load is "Recent (7d)"; "All" remains for full search
- Each row carries `data-recent="0|1"` so the tab toggle is one class flip in JS
- 'Last 7 days' added to the stats strip
- Empty-state message when the 7d tab has nothing to show

## Validation

**Unit tests on dispatch_alerts:**
- Events queued exactly at consecutive_failures ∈ {1, 3, 12, 72}
- Same (sub, event_type) throttled within 24h
- DRY_RUN does not pollute alert_history
- Recoveries do not queue alerts (per policy)

**Dry-run (run 25643356983):**
- All six phases executed, exit success
- No alerts fired (correct: `bot_health.json` on main already records floridapanthers + caps as long-failing, no transitions occurred)
- Caught the same in-flight DM as PR #10's dry-run

**HTML render against the real 31k-entry log:**
- Markup verified: tabs, stats, empty-state, data-recent attrs
- 200 rows rendered, 38KB output

## Files

- `health_utils.py` — alert queue + dispatch
- `bot_config.py` — notify_owner helper
- `cross_sub_ban_bot.py` — wires dispatch into PHASE 5
- `modmail_utils.py` — /xsub history handler + help text
- `inbox_utils.py` — DM help text + history-redirect
- `log_utils.py` — Recent (7d) tab in HTML

Authored with Claude assistance.