### PR TITLE
Retry git push with backoff on transient failures

### DIFF
--- a/.github/workflows/run_bot.yml
+++ b/.github/workflows/run_bot.yml
@@ -46,8 +46,22 @@ jobs:
 
           if ! git diff --cached --quiet; then
             git commit -m "Update ban database and public log"
-            git pull origin main --rebase
-            git push
+            # Retry pull+push with backoff. GitHub occasionally returns
+            # 500 on push (transient backend hiccup); without a retry,
+            # the whole run gets flagged failure even though the bot
+            # work itself succeeded. Three attempts: 5s, 30s, 120s.
+            for delay in 0 5 30 120; do
+              if [ "$delay" != "0" ]; then
+                echo "::warning::Push attempt failed; retrying in ${delay}s..."
+                sleep "$delay"
+              fi
+              if git pull origin main --rebase && git push; then
+                echo "Push succeeded."
+                exit 0
+              fi
+            done
+            echo "::error::Push failed after 4 attempts (5s/30s/120s backoff)."
+            exit 1
           else
             echo "No state changes to commit."
           fi


### PR DESCRIPTION
## What

Wraps the post-run `git pull + push` in a retry loop with 5s / 30s / 120s backoff (4 attempts total).

## Why

Run 25675650392 at 14:14 UTC today completed all five phases successfully but the final commit-and-push step got HTTP 500 from github.com's git server during push. GitHub Status showed 'All Systems Operational' — this is a known transient hiccup. Without a retry, transient pushes paint the run red even though all bot work succeeded.

## Behavior

- Try pull+push immediately
- On failure, sleep 5s and retry
- On failure, sleep 30s and retry
- On failure, sleep 120s and retry
- Only after all 4 attempts fail does the step error out
- Each retry emits a `::warning::` annotation so attempts are visible in the run summary

Worst-case run time goes from ~2 min to ~5 min if pushes keep failing, which is well within the 20-min cron cadence.

## Files

- `.github/workflows/run_bot.yml` — retry loop in the 'Commit and push state' step
- `dry_run.yml` unchanged — it doesn't push anything

Authored with Claude assistance.